### PR TITLE
Make MAX_PKT easily configurable as workaround for Pybricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Use this library to communicate as a Powered UP (PUP) Device with LEGO smart hub
 - import pupremote.py
 - import demo_pybricks_inventorhub or _technichub
 
+## Compatibility with Pybricks
+If you get checksum errors it could be due to a known issue with 32 byte packet size in Pybricks. Pass max_packet_size=16 when instantiating PUPRemoteHub and PUPRemoteSensor classes to work around this issue.
+
 ## Contributing
 
 Please fork and streamline the protocol. There are also some TODOs below you can help with. 

--- a/src/lpf2.py
+++ b/src/lpf2.py
@@ -51,7 +51,7 @@ def default_cmd_callback(size, buf):
 
 
 class LPF2(object):
-    def __init__(self, modes, sensor_id=WeDo_Ultrasonic, timer=4, freq=5, debug=False):
+    def __init__(self, modes, sensor_id=WeDo_Ultrasonic, timer=4, freq=5, debug=False, max_packet_size=MAX_PKT):
         self.txTimer = timer
         self.modes = modes
         self.current_mode = 0
@@ -65,6 +65,7 @@ class LPF2(object):
         self.cmd_call_back = default_cmd_callback
         self.last_nack = 0
         self.debug = debug
+        self.max_packet_size = max_packet_size
 
     @staticmethod
     def mode(
@@ -131,7 +132,7 @@ class LPF2(object):
             bin_data = struct.pack(format[data_type], data)
         elif isinstance(data, str):
             # String. Convert to bytes of max size.
-            bin_data = bytes(data, "UTF-8")[:MAX_PKT]
+            bin_data = bytes(data, "UTF-8")[:self.max_packet_size]
         elif isinstance(data, bytes):
             bin_data = data
         elif isinstance(data, bytearray):
@@ -222,7 +223,7 @@ class LPF2(object):
                     if ck == self.readchar():
                         return buf
                     else:
-                        print("Checksum error")
+                        print("Checksum error. Try reducing max_packet_size to 16 if using Pybricks.")
 
 
     def writeIt(self, array):
@@ -283,7 +284,7 @@ class LPF2(object):
 
     def padString(self, string, num, startNum):
         reply = bytearray(string, "UTF-8")
-        reply = reply[:MAX_PKT]
+        reply = reply[:self.max_packet_size]
         exp = __num_bits(len(reply) - 1)
         reply = reply + b"\x00" * (2**exp - len(string))
         exp = exp << 3

--- a/src/pupremote_hub.py
+++ b/src/pupremote_hub.py
@@ -36,11 +36,13 @@ class PUPRemote:
     and their formats. Contains encoding/decoding functions.
     """
 
-    def __init__(self):
+    def __init__(self, max_packet_size=MAX_PKT):
         # Store commands, size and format
         self.commands = []
         # Store mode names (commands) to look up their index
         self.modes = {}
+        # Optional override for max packet size for Pybricks compatibility
+        self.max_packet_size = max_packet_size
 
     def add_channel(self, mode_name: str, to_hub_fmt: str =""):
         """
@@ -80,7 +82,7 @@ class PUPRemote:
 
         """
         if to_hub_fmt == "repr" or from_hub_fmt == "repr":
-            msg_size = MAX_PKT
+            msg_size = self.max_packet_size
         else:
             size_to_hub_fmt = struct.calcsize(to_hub_fmt)
             size_from_hub_fmt = struct.calcsize(from_hub_fmt)
@@ -135,16 +137,16 @@ class PUPRemoteHub(PUPRemote):
 
     :param port: The port to which the PUPRemoteSensor is connected.
     :type port: Port (Example: Port.A)
-    :param power: Set to True if the PUPRemoteSensor needs 8V power on M+ wire.
-    :type power: bool
+    :param max_packet_size: Set to 16 for Pybricks compatibility, defaults to 32.
+    :type max_packet_size: int
     """
     
     def _int8_to_uint8(self,arr):
         return [((i+128)&0xff)-128 for i in arr]
 
 
-    def __init__(self, port):
-        super().__init__()
+    def __init__(self, port, max_packet_size=MAX_PKT):
+        super().__init__(max_packet_size)
         self.port = port
         try:
             self.pup_device = PUPDevice(port)


### PR DESCRIPTION
After https://github.com/antonvh/PUPRemote/issues/19 I made a couple of small changes to make MAX_PKT easily configurable when instantiating the PUPRemote classes. I've tested it on my Mindstorms hub with LMS ESP32 and it seems to work as expected.

I also added a note to the README.md so other users can hopefully resolve this problem without having to raise a GitHub issue. I also added a reference to max_packet_size configuration in the 'Checksum error' text so it's easy to find. Please let me know if this is not up to standards or not the way to go about this.

Thanks for making these awesome projects!

EDIT: forgot to mention I removed the wrongly documented power option for PUPRemoteHub class from the docstring.