### PR TITLE
fix of KeyError on attempt of getting a format of message in CALL method in case of channel.

### DIFF
--- a/src/pupremote.py
+++ b/src/pupremote.py
@@ -139,7 +139,7 @@ class PUPRemote:
                 SIZE: msg_size,
             }
         )
-        if command_type == CALLBACK:
+        if command_type == [CALLBACK, CHANNEL]:
             self.commands[-1][FROM_HUB_FORMAT] = from_hub_fmt
             # self.commands[-1][CALLABLE] = eval(mode_name)
 

--- a/src/pupremote_hub.py
+++ b/src/pupremote_hub.py
@@ -126,7 +126,7 @@ class PUPRemote:
             SIZE: msg_size,
             }
         )
-        if command_type == CALLBACK:
+        if command_type in [CALLBACK, CHANNEL]:
             self.commands[-1][FROM_HUB_FORMAT] = from_hub_fmt
             # self.commands[-1][CALLABLE] = eval(mode_name)
 


### PR DESCRIPTION
To reproduce the issue: 

code on sensor side: 
```
from pupremote import  PUPRemoteSensor, SPIKE_ULTRASONIC

value=0

sensor=PUPRemoteSensor(sensor_id=SPIKE_ULTRASONIC, power = True)
sensor.add_channel('chl', to_hub_fmt='3b')

while(True):
    connected=sensor.process()
    
    value = value + 1 if value < 100 else 0
    sensor.update_channel('chl', value, value, value)
    print(value)
```

code on hub (Inventor hub in my case):

```
from pybricks.hubs import InventorHub
from pybricks.parameters import Button, Color, Direction, Port, Side, Stop
from pybricks.pupdevices import ColorSensor, Motor, UltrasonicSensor
from pybricks.robotics import DriveBase
from pybricks.tools import StopWatch, wait, run_task

from pupremote_hub import PUPRemoteHub

hub = InventorHub()
p = PUPRemoteHub(Port.A)

p.add_channel('chl', '3b')

while(True):
    try: 
        print(p.call('chl'))
    except Exception as ex:
        raise

```

Result: 
```
File "pupremote_hub.py", line 347, in call
KeyError: 3
```