### PR TITLE
pybricks style error handling - pass exceptions to caller as is

### DIFF
--- a/src/pupremote_hub.py
+++ b/src/pupremote_hub.py
@@ -179,11 +179,7 @@ class PUPRemoteHub(PUPRemote):
     def __init__(self, port, max_packet_size=MAX_PKT):
         super().__init__(max_packet_size)
         self.port = port
-        try:
-            self.pup_device = PUPDevice(port)
-        except OSError:
-            self.pup_device = None
-            print("PUPDevice not ready on port", port)
+        self.pup_device = PUPDevice(port)
 
     def call(self, mode_name: str, *argv, wait_ms=0):
         """
@@ -204,11 +200,7 @@ class PUPRemoteHub(PUPRemote):
         size = self.commands[mode][SIZE] 
         # Dummy read action to work around mode setting bug in Pybricks beta 2.2.0b8
         # Also check if a sensor or sensor emulator is connected.abs
-        try:
-            self.pup_device.read(mode)
-        except:
-            print("PUPRemote Error: Nothing connected or no script running on remote\n")
-            return None
+        self.pup_device.read(mode)
 
         if FROM_HUB_FORMAT in self.commands[mode]: 
             payl = self.encode(size, self.commands[mode][FROM_HUB_FORMAT], *argv)


### PR DESCRIPTION
Behavior is now same as with pybricks + Lego sensors:

- if a device fails in \_\_init\_\_ it is not usable (e.g. if not connected throws '[Errno 19] ENODEV')
- if a device fails later (e.g. after disconnect throws '[Errno 19] ENODEV')  but will continue working when reconnected.

I tested with my [minimal example](https://gist.github.com/kai-morich/d4b0a80fe84b136ae6db04d23b38a575) and while loop including try/except:

```python
from pybricks.pupdevices import ForceSensor
from pybricks.parameters import Port
from pybricks.tools import wait
from pupremote_hub import PUPRemoteHub

print('force')
fs = ForceSensor(Port.A)
print('remote')
rh = PUPRemoteHub(Port.B)
rh.add_command('led', '', 'B')
print('run')
while True:
    try:
        v = min(255, int(fs.force()*25.0)) # map from 0-10.xx to 0-255
        print(v)
        rh.call('led', v)
        wait(100)
    except Exception as ex:
        print(ex)
```

Note: I haven't checked if the same would make sense for `pupremote.py` running on the LMS-ESP32
