### PR TITLE
Fix ENODEV on PUPRemoteHub write to a non-current mode

### DIFF
--- a/src/pupremote.py
+++ b/src/pupremote.py
@@ -441,6 +441,7 @@ class PUPRemoteHub(PUPRemote):
                 assert (
                     len(argv) == num_args
                 ), "Expected {} argument(s) in call '{}'".format(num_args, mode_name)
+            self.pup_device.read(mode)
             payl = self.encode(size, self.commands[mode][FROM_HUB_FORMAT], *argv)
             self.pup_device.write(
                 mode, self._int8_to_uint8(tuple(payl + b"\x00" * (size - len(payl))))
@@ -491,6 +492,7 @@ class PUPRemoteHub(PUPRemote):
                 assert (
                     len(argv) == num_args
                 ), "Expected {} argument(s) in call '{}'".format(num_args, mode_name)
+            await self.pup_device.read(mode)
             payl = self.encode(size, self.commands[mode][FROM_HUB_FORMAT], *argv)
             await self.pup_device.write(
                 mode, self._int8_to_uint8(tuple(payl + b"\x00" * (size - len(payl))))

--- a/src/pupremote_hub.py
+++ b/src/pupremote_hub.py
@@ -264,6 +264,7 @@ class PUPRemoteHub(PUPRemote):
                 assert (
                     len(argv) == num_args
                 ), "Expected {} argument(s) in call '{}'".format(num_args, mode_name)
+            self.pup_device.read(mode)
             payl = self.encode(size, self.commands[mode][FROM_HUB_FORMAT], *argv)
             self.pup_device.write(
                 mode,
@@ -316,6 +317,7 @@ class PUPRemoteHub(PUPRemote):
             num_args = self.commands[mode][ARGS_FROM_HUB]
             if num_args >= 0:
                 assert len(argv) == num_args, "Args mismatch in {}".format(mode_name)
+            await self.pup_device.read(mode)
             payl = self.encode(size, self.commands[mode][FROM_HUB_FORMAT], *argv)
             await self.pup_device.write(
                 mode,


### PR DESCRIPTION
## Problem

### Detailed description in https://github.com/AntonsMindstorms/PUPRemote/issues/52

Calling a second (or later) registered command via `PUPRemoteHub.call()`
or `call_multitask()` reliably raises `OSError: [Errno 19] ENODEV`,
while the first registered command always works. This reproduces with
completely stock code on both hub and sensor side — no custom sensor
firmware or async variant involved — as long as the sensor doesn't
respond to a write-triggered mode switch within a few milliseconds.

Minimal repro: register two commands (`serv1`, `serv2`) on a
PUPRemoteSensor, then from the hub only ever call `serv2`. `serv1`
(mode 0, the default active mode after connect) works fine; `serv2`
(mode 1) fails with ENODEV as soon as it's called, even though the
sensor is connected and healthy.

## Root cause

I traced this through the actual Pybricks firmware source
(`lib/pbio/src/port_lump.c`, `lib/lego/device.c` in the
pybricks-micropython repo). `PUPDevice.write(mode, data)` is
implemented as an atomic "set mode, then set data" operation:

1. If `mode` differs from the device's current mode, the firmware
   first requests a mode switch (`LUMP_CMD_SELECT`) and only proceeds
   to send the actual data once the device confirms the new mode by
   sending a data message tagged with that mode.
2. While a data-set request is pending, the port's send thread does
   `AWAIT_MS(timer, 1)` between mode data messages instead of
   respecting the standard 100ms keepalive timer. Its "no response"
   error counter (`EV3_UART_DATA_KEEP_ALIVE_MAX_MISSED = 2`) still
   applies, so unresponsive sensors get 
   `EV3_UART_DATA_KEEP_ALIVE_TIMEOUT * (MAX_MISSED + 1)` ≈ 3-4ms
   before the port is marked `PBDRV_LEGODEV_LUMP_STATUS_ERR`, which
   surfaces to Pybricks as ENODEV.
3. Any sensor-side heartbeat/polling loop with a period at or above
   that (e.g. 20ms, which is common and reasonable for cooperative
   MicroPython sensor firmware) cannot possibly answer in time. The
   write is dropped before the sensor even sees it.

By contrast, `PUPDevice.read(mode)` triggering the same mode switch is
tolerant: it goes through the regular keepalive/timeout path (100ms
keepalive, ~500ms mode-switch retry window), which comfortably
accommodates typical sensor-side loop timing.

This means any write to a mode that isn't already the device's
current mode is structurally likely to fail with ENODEV, independent
of sensor implementation quality — it's a timing mismatch between
Pybricks' write-triggered mode-switch path and realistic sensor
heartbeat intervals.

## Fix

In both `PUPRemoteHub.call()` and `_execute_call()` (used by
`call_multitask()`), perform a `read(mode)` immediately before
`write(mode, ...)`. This forces any necessary mode switch through the
tolerant read path first. By the time the write executes, the device
is already in the target mode, so the write requires no mode switch
and completes normally.

## Side effects

- Alternating between two write-mode commands incurs the sensor
  type's mode-switch "stale data" delay (e.g. ~50ms for the emulated
  SPIKE Ultrasonic sensor ID) each time the mode differs from the
  previous call. Repeated calls to the *same* command are unaffected.
- No sensor-side changes are required.

## Testing

Reproduced and fixed on a Pybricks hub (Port D) talking to a
MicroPython sensor (LMS-ESP32) running stock `pupremote.PUPRemoteSensor`
with two `add_command()` calls (`serv1`, `serv2`). Without the patch,
calling only the second-registered command raises ENODEV every time;
with the patch, it runs indefinitely with no errors.