### PR TITLE
Flush buffer on checksum error

### DIFF
--- a/src/lpf2.py
+++ b/src/lpf2.py
@@ -445,6 +445,7 @@ class LPF2(object):
                     if ck == self.readchar(1):
                         return buf, wrt_mode
                     else:
+                        self.flush()
                         print(
                             "Checksum error. Try reducing max_packet_size to 16 if using Pybricks."
                         )


### PR DESCRIPTION
When running a color blob detection on the OpenMV AE3, it seems that calling process() once per loop isn't often enough. This leads to "Checksum error. Try reducing max_packet_size to 16 if using Pybricks.". Reducing the max_packet_size does not help.

I also observed that the checksum error occurs more frequently the longer it runs.

This eventually leads to either...

1) A corrupted message passing the checksum by chance (...it's just a 1 byte checksum, so it's not improbable), and causing a list index out of range in...
https://github.com/AntonsMindstorms/PUPRemote/blob/4de7e28112a1e24e27dd8ba83da9a5f83be2eec9/src/pupremote.py#L331

2) If we wrap process() in a try, the checksum error frequency will continue increasing to the point where the sensor gets disconnected. It'll automatically reconnect back, but this leads to a short period when the sensor cannot be read.

Adding a flush() when a checksum error occurs appears to resolve the issue. Checksum errors still occur (...which is expected as process() isn't being called often enough), but the frequency of the checksum error do not increase.